### PR TITLE
Remove debug outlines from global styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -120,9 +120,3 @@
     @apply bg-background text-foreground;
   }
 }
-/* DEBUG: visualize click blockers */
-* { outline: 1px solid rgba(255, 0, 0, 0.08); }
-.fixed, .absolute, [class*="fixed"], [class*="absolute"] {
-  outline: 2px solid rgba(0, 128, 255, 0.6) !important;
-}
-


### PR DESCRIPTION
## Summary
- remove debug outline styles from the global stylesheet to eliminate unintended red borders

## Testing
- npm run dev


------
https://chatgpt.com/codex/tasks/task_e_68dc1ee8915483328cc7d0fc2c09aebd